### PR TITLE
FAC3D: cylinder-distance weighted umbrella smoothing

### DIFF
--- a/applications/q2p1_fac3d/app_init.f90
+++ b/applications/q2p1_fac3d/app_init.f90
@@ -67,7 +67,8 @@ SUBROUTINE General_init_ext(MDATA,MFILE)
  USE PP3D_MPI
  USE MESH_Structures
  USE var_QuadScalar, ONLY : cGridFileName,nSubCoarseMesh,cProjectFile,&
-   cProjectFolder,cProjectNumber,nUmbrellaSteps,mg_mesh,nInitUmbrellaSteps
+   cProjectFolder,cProjectNumber,nUmbrellaSteps,mg_mesh,nInitUmbrellaSteps,&
+   bFAC3D_CylUmbrellaWeight,dFAC3D_CylCenter,dFAC3D_CylRadius,dFAC3D_CylLength
  USE Transport_Q2P1, ONLY : Init_FAC3D_Handlers, Init_QuadScalar,LinSc,QuadSc
  USE Parametrization, ONLY: InitParametrization,ParametrizeBndr,&
      ProlongateParametrization_STRCT,InitParametrization_STRCT,ParametrizeBndryPoints,&
@@ -157,6 +158,14 @@ SUBROUTINE General_init_ext(MDATA,MFILE)
  
  CALL Init_QuadScalar(mfile)
  call Init_FAC3D_Handlers()
+
+ bFAC3D_CylUmbrellaWeight = .TRUE.
+ dFAC3D_CylCenter = (/0.5d0, 0.2d0, 0.205d0/)
+ dFAC3D_CylRadius = 0.05d0
+ dFAC3D_CylLength = 0.4105d0
+ if ((myid.eq.0).or.(myid.eq.1)) then
+   write(*,'(A)') 'FAC3D umbrella weighting: analytic cylinder distance is enabled'
+ end if
 
  IF (myid.EQ.0) THEN
   NLMAX = LinSc%prm%MGprmIn%MedLev

--- a/source/src_mesh/umbrella_smoother.f90
+++ b/source/src_mesh/umbrella_smoother.f90
@@ -130,7 +130,9 @@ module umbrella_smoother
   USE Parametrization, ONLY: ParametrizeBndryPoints_STRCT
 !   use Parametrization, only: ParametrizeBndr
   use Sigma_User, only: mySigma,Shell_dist
-  use var_QuadScalar, only: tMultiMesh,FictKNPR
+  use var_QuadScalar, only: tMultiMesh,FictKNPR, &
+                            bFAC3D_CylUmbrellaWeight, &
+                            dFAC3D_CylCenter,dFAC3D_CylRadius,dFAC3D_CylLength
   
   !USE STL_Processing, ONLY : dEpsDist
   implicit none
@@ -205,25 +207,31 @@ module umbrella_smoother
     f(i) = f(i)/w(i)
    end DO
   
-   IF (ADJUSTL(TRIM(mySigma%cType)).EQ."HEAT") THEN
-    qscStruct%AuxU = dEpsDist
-    qscStruct%AuxV = dEpsDist
-    qscStruct%AuxW = dEpsDist
-    CALL calcDistanceFunction_heat(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
-                             qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW,qscStruct%defW)
-   END IF
-   IF (ADJUSTL(TRIM(mySigma%cType)).EQ."SSE".OR.ADJUSTL(TRIM(mySigma%cType)).EQ."DIE") THEN
-    qscStruct%AuxU = dEpsDist
-    qscStruct%AuxV = dEpsDist
-    CALL calcDistanceFunction_sse(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
-                             qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW)
-   END IF
-   IF (ADJUSTL(TRIM(mySigma%cType)).EQ."TSE") THEN
-    qscStruct%AuxU = dEpsDist
-    qscStruct%AuxV = dEpsDist
-    qscStruct%AuxW = dEpsDist
-    CALL QuadScalar_MixerKnpr(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
-                             qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW)
+   IF (bFAC3D_CylUmbrellaWeight) THEN
+    CALL ComputeFAC3DCylDistance(nvt,dcorvg,qscStruct%AuxU)
+    qscStruct%AuxV(1:nvt) = qscStruct%AuxU(1:nvt)
+    qscStruct%AuxW(1:nvt) = qscStruct%AuxU(1:nvt)
+   ELSE
+    IF (ADJUSTL(TRIM(mySigma%cType)).EQ."HEAT") THEN
+     qscStruct%AuxU = dEpsDist
+     qscStruct%AuxV = dEpsDist
+     qscStruct%AuxW = dEpsDist
+     CALL calcDistanceFunction_heat(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
+                              qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW,qscStruct%defW)
+    END IF
+    IF (ADJUSTL(TRIM(mySigma%cType)).EQ."SSE".OR.ADJUSTL(TRIM(mySigma%cType)).EQ."DIE") THEN
+     qscStruct%AuxU = dEpsDist
+     qscStruct%AuxV = dEpsDist
+     CALL calcDistanceFunction_sse(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
+                              qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW)
+    END IF
+    IF (ADJUSTL(TRIM(mySigma%cType)).EQ."TSE") THEN
+     qscStruct%AuxU = dEpsDist
+     qscStruct%AuxV = dEpsDist
+     qscStruct%AuxW = dEpsDist
+     CALL QuadScalar_MixerKnpr(dcorvg,kvert2,kedge2,karea2,nel2,nvt2,nat2,net2,&
+                              qscStruct%AuxU,qscStruct%AuxV,qscStruct%AuxW)
+    END IF
    END IF
   
    DO i=1,nvt
@@ -291,7 +299,8 @@ module umbrella_smoother
    CONTAINS
   
   subroutine GetWeight(x,y,z,t,f)
-  USE var_QuadScalar , ONLY :dCGALtoRealFactor
+  USE var_QuadScalar , ONLY :dCGALtoRealFactor, &
+                              bFAC3D_CylUmbrellaWeight
   IMPLICIT NONE
   real*8 x,y,z,t,f
   real*8 d1,d2,d3
@@ -307,7 +316,19 @@ module umbrella_smoother
    f = 1d0
   ELSE
   
-  dScaleFactor = 5d0*6d0*(6d0/mySigma%Dz_Out)
+  if (ABS(mySigma%Dz_Out).gt.1d-12) then
+   dScaleFactor = 5d0*6d0*(6d0/mySigma%Dz_Out)
+  else
+   dScaleFactor = 1d0
+  end if
+
+  IF (bFAC3D_CylUmbrellaWeight) THEN
+   d1 = dScaleFactor*qscStruct%AuxU(i)
+   CALL KernelFunction(d1,f1)
+   f = MIN(f1,25d0)
+   f = f**2.3d0
+   RETURN
+  END IF
 
   IF (ADJUSTL(TRIM(mySigma%cType)).EQ."SSE") THEN
    d1 = dScaleFactor*(0.5d0*mySigma%Dz_Out - SQRT(X*X + Y*Y))
@@ -371,6 +392,27 @@ module umbrella_smoother
   f = max(daux,0.8d0)
   
   end subroutine KernelFunction
+
+  subroutine ComputeFAC3DCylDistance(nLocalVtx,dcoor,dist)
+  implicit none
+  integer, intent(in) :: nLocalVtx
+  real*8, dimension(:,:), intent(in) :: dcoor
+  real*8, dimension(:), intent(inout) :: dist
+  integer :: iVtx
+  real*8 :: dx,dy,dzAbs,rxy,zGap,halfLen
+
+  halfLen = 0.5d0*dFAC3D_CylLength
+
+  DO iVtx=1,nLocalVtx
+   dx = dcoor(1,iVtx) - dFAC3D_CylCenter(1)
+   dy = dcoor(2,iVtx) - dFAC3D_CylCenter(2)
+   dzAbs = ABS(dcoor(3,iVtx) - dFAC3D_CylCenter(3))
+   rxy = SQRT(dx*dx + dy*dy)
+   zGap = dzAbs - halfLen
+   dist(iVtx) = MAX(rxy - dFAC3D_CylRadius,zGap)
+  END DO
+
+  end subroutine ComputeFAC3DCylDistance
   
   end
   !

--- a/source/src_quadLS/QuadSc_var.f90
+++ b/source/src_quadLS/QuadSc_var.f90
@@ -400,6 +400,10 @@ MODULE var_QuadScalar
   REAL*8, ALLOCATABLE :: Viscosity(:), Shearrate(:),Temperature(:),ElemSizeDist(:),MaxShearRate(:)
   REAL*8, ALLOCATABLE :: Temperature_AVG(:)
   INTEGER :: iTemperature_AVG = 0
+  LOGICAL :: bFAC3D_CylUmbrellaWeight = .FALSE.
+  REAL*8 :: dFAC3D_CylCenter(3) = (/0.5d0, 0.2d0, 0.205d0/)
+  REAL*8 :: dFAC3D_CylRadius = 0.05d0
+  REAL*8 :: dFAC3D_CylLength = 0.4105d0
   TYPE tCGALObjects
     REAL*8, ALLOCATABLE :: Block(:)
     REAL*8, ALLOCATABLE :: Wire(:)


### PR DESCRIPTION
## Summary
  - enable FAC3D-specific umbrella weighting in setup
  - compute analytic distance to benchmark cylinder and use it in us_UmbrellaSmoother weighting
  - keep behavior isolated to FAC3D via dedicated flag/parameters

  ## Validation
  - built target: q2p1_fac3d (build-release)
  - no changes outside FAC3D weighting path