### PR TITLE
Align FeatFloWer with PE's PE_-prefixed CMake options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,7 +153,7 @@ cmake_dependent_option(
 )
 
 cmake_dependent_option(
-  MPI                              # Dependent Option name
+  PE_USE_MPI                       # Dependent Option name (PE-owned, PE_-prefixed)
   "Enable MPI support in PE"       # Description
   ON                               # Value when condition is true (parallel PE needs MPI)
   "USE_PE;NOT USE_PE_SERIAL_MODE"  # Condition: USE_PE=ON AND USE_PE_SERIAL_MODE=OFF
@@ -472,8 +472,16 @@ if(USE_PE)
 
   # Propagate FBM acceleration to PE library's HashGrid
   if(ENABLE_FBM_ACCELERATION)
-    set(USE_ACCELERATED_POINT_QUERY ON CACHE BOOL
+    set(PE_USE_ACCELERATED_POINT_QUERY ON CACHE BOOL
       "Enable HashGrid spatial hashing in PE (controlled by ENABLE_FBM_ACCELERATION)" FORCE)
+  endif()
+
+  # Forward FeatFloWer's CGAL choice to the PE library. PE removed its
+  # USE_CGAL deprecated alias; its own option is now PE_USE_CGAL (default OFF),
+  # so we must set it explicitly to keep PE's CGAL code paths compiled.
+  if(USE_CGAL)
+    set(PE_USE_CGAL ON CACHE BOOL
+      "Build PE with CGAL support (controlled by FeatFloWer USE_CGAL)" FORCE)
   endif()
 
   add_subdirectory(libs/pe)

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,7 +27,7 @@ cmake -S . -B build-ninja-release -G Ninja
   -DBUILD_APPLICATIONS=ON 
   -DUSE_PE=ON 
   -DUSE_PE_SERIAL_MODE=ON 
-  -DUSE_JSON=ON 
+  -DPE_USE_JSON=ON 
   -DCMAKE_C_COMPILER=mpicc 
   -DCMAKE_CXX_COMPILER=mpicxx 
   -DCMAKE_Fortran_COMPILER=mpifort
@@ -36,7 +36,7 @@ cmake -S . -B build-ninja-release -G Ninja
 **Critical Flags:**
 - `-DUSE_PE=ON`: Enables the Physics Engine.
 - `-DUSE_PE_SERIAL_MODE=ON`: Enables Serial PE mode (essential for large particles/benchmarks).
-- `-DUSE_JSON=ON`: **Mandatory** for Serial Mode to load `example.json` configuration.
+- `-DPE_USE_JSON=ON`: **Mandatory** for Serial Mode to load `example.json` configuration.
 
 ## 3. Workflow: Building & Partitioning
 
@@ -66,7 +66,7 @@ python3 ../../../tools/PyPartitioner.py <N_PARTS> 1 1 NEWFAC <PROJECT_FILE>
 ### Required Files in Run Directory
 1.  **Executable**: `q2p1_bench_sedimentation`
 2.  **CFD Config**: `_data/q2p1_param.dat` (Controls `MaxNumStep` for CFD)
-3.  **PE Config**: `example.json` (Required if `-DUSE_JSON=ON`. Controls particle physics parameters).
+3.  **PE Config**: `example.json` (Required if `-DPE_USE_JSON=ON`. Controls particle physics parameters).
     *   *Source:* `libs/pe/pe/interface/example.json`
 4.  **Multigrid**: `_data/MG.dat` (Often staged automatically, but verify).
 5.  **Metis Lib**: `libmetis.so` (If re-partitioning is needed).

--- a/applications/q2p1_hashgrid_test/README.md
+++ b/applications/q2p1_hashgrid_test/README.md
@@ -33,7 +33,7 @@ cd build_test_baseline
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DUSE_PE=ON \
       -DUSE_PE_SERIAL_MODE=ON \
-      -DUSE_ACCELERATED_POINT_QUERY=OFF \
+      -DPE_USE_ACCELERATED_POINT_QUERY=OFF \
       -DBUILD_APPLICATIONS=ON \
       ..
 
@@ -50,7 +50,7 @@ cd build_test_accelerated
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DUSE_PE=ON \
       -DUSE_PE_SERIAL_MODE=ON \
-      -DUSE_ACCELERATED_POINT_QUERY=ON \
+      -DPE_USE_ACCELERATED_POINT_QUERY=ON \
       -DBUILD_APPLICATIONS=ON \
       ..
 
@@ -148,7 +148,7 @@ Add diagnostic output in `libs/pe/src/interface/object_queries.cpp` to print whi
 If the counts differ:
 
 1. Check that both builds are using PE_SERIAL_MODE
-2. Verify the CMake configuration (check for `USE_ACCELERATED_POINT_QUERY`)
+2. Verify the CMake configuration (check for `PE_USE_ACCELERATED_POINT_QUERY`)
 3. Enable debug output in the point query code to trace the discrepancy
 4. Try with fewer spheres (e.g., 5×5×5 = 125) to test below the activation threshold
 

--- a/build_guide.md
+++ b/build_guide.md
@@ -117,10 +117,10 @@ These options control which components and features are enabled or disabled.
 | `BUILD_APPLICATIONS`            | `ON`    | Enable build of applications.                                                                              | Requires the `FullC0ntact` subdirectory.                                                              |
 | `BUILD_BOUNDARY_LAYER_TOOLS`    | `OFF`   | Build the boundary layer tools.                                                                            | Forces `USE_OPENMESH=ON`.                                                                             |
 | `USE_HYPRE`                     | `OFF`   | Use the HYPRE (High Performance Preconditioners) library.                                                  | Builds bundled HYPRE. Adds `HypreSolver.f90`.                                                        |
-| `USE_PE`                        | `OFF`   | Use the PE (rigid body physics engine) library.                                                            | Builds `libs/pe`. Enables `MPI` option.                                                              |
+| `USE_PE`                        | `OFF`   | Use the PE (rigid body physics engine) library.                                                            | Builds `libs/pe`. Enables `PE_USE_MPI` option.                                                       |
 | `USE_PE_SERIAL_MODE`            | `OFF`   | Use serial PE mode for large particles that span multiple domains.                                         | Only available when `USE_PE=ON`. See section 5.2.                                                    |
 | `SED_BENCH`                     | `OFF`   | Enable sedimentation benchmark output (force/position/velocity per timestep).                              | Adds `-DSED_BENCH` preprocessor flag; activates `SED_BENCH_FORCE/POS/VEL` log lines.                |
-| `VERIFY_HASHGRID`               | `OFF`   | Run HashGrid alpha acceleration alongside brute-force baseline for correctness verification.               | **Significant performance overhead.** For debugging only; do not use in production runs.             |
+| `PE_VERIFY_HASHGRID`            | `OFF`   | Run HashGrid alpha acceleration alongside brute-force baseline for correctness verification.               | **Significant performance overhead.** For debugging only; do not use in production runs.             |
 | `SHOW_BUILD_IDS`                | `OFF`   | Display all available build IDs (compiler/flag configurations) and exit.                                   | Useful for developers to see predefined toolchain settings.                                           |
 
 ## 5. Specific Feature Configurations
@@ -262,7 +262,7 @@ The FBM geometry query `fbm_getFictKnprFC2` — which classifies every mesh DOF 
 *   **Runtime control:** `SimPar@UseHashGridAccel` in `q2p1_param.dat`
 *   On timestep 1 the brute-force baseline (`verifyAllParticles`) is used because the HashGrid is not yet built.
 *   From timestep 2 onwards, `checkAllParticles` (HashGrid lookup) is called if enabled.
-*   To verify correctness, build with `-DVERIFY_HASHGRID=ON`, which runs both paths in parallel and reports any mismatches (at significant cost).
+*   To verify correctness, build with `-DPE_VERIFY_HASHGRID=ON`, which runs both paths in parallel and reports any mismatches (at significant cost).
 
 ### 6.3. Force Integration Acceleration (KVEL/KEEL/KAAL candidate elements)
 
@@ -289,7 +289,7 @@ This produces a pure brute-force binary where the acceleration code paths are ne
 |---|---|---|---|---|
 | Alpha / HashGrid | `SimPar@UseHashGridAccel` | `-DENABLE_FBM_ACCELERATION` | ON | ON |
 | Force / KVEL | `SimPar@UseKVELAccel` | `-DENABLE_FBM_ACCELERATION` | ON | ON |
-| HashGrid verification | N/A (debug only) | `-DVERIFY_HASHGRID=ON` | N/A | OFF |
+| HashGrid verification | N/A (debug only) | `-DPE_VERIFY_HASHGRID=ON` | N/A | OFF |
 
 **Required CMake flags:** `-DUSE_PE=ON -DUSE_PE_SERIAL_MODE=ON`
 

--- a/docs/md_docs/guide_02_q2p1_bench_sedimentation_pe_serial_from_scratch.md
+++ b/docs/md_docs/guide_02_q2p1_bench_sedimentation_pe_serial_from_scratch.md
@@ -63,7 +63,7 @@ If the agent is limited to a restricted mode (e.g., “write-workspace” only),
 - `slurm_set_addr: Unable to resolve <controller>` (Slurm submission)
 
 Practical workaround if network is blocked:
-- Use `-DEIGEN=OFF` and point JSON to a pre-downloaded source via
+- Use `-DPE_USE_EIGEN=OFF` and point JSON to a pre-downloaded source via
   `-DFETCHCONTENT_SOURCE_DIR_JSON=/path/to/json-src`.
 
 This guide assumes a mode with **both filesystem write access and outbound network access**. For Codex CLI,
@@ -89,15 +89,15 @@ cmake -S . -B build-ninja-release -G Ninja \
   -DBUILD_APPLICATIONS=ON \
   -DUSE_PE=ON \
   -DUSE_PE_SERIAL_MODE=ON \
-  -DUSE_JSON=ON \
+  -DPE_USE_JSON=ON \
   -DSED_BENCH=ON \
-  -DVERIFY_HASHGRID=OFF \
+  -DPE_VERIFY_HASHGRID=OFF \
   -DCMAKE_C_COMPILER=mpicc \
   -DCMAKE_CXX_COMPILER=mpicxx \
   -DCMAKE_Fortran_COMPILER=mpifort
 ```
 
-**Important:** `-DUSE_JSON=ON` is **required** for PE Serial Mode. `-DSED_BENCH=ON` enables the sedimentation benchmark output (e.g. `SED_BENCH_VEL` lines). `-DVERIFY_HASHGRID=OFF` disables hashgrid verification overhead. The setup functions (`setupParticleBenchSerial`, etc.) load runtime configuration from `example.json` via `SimulationConfig::loadFromFile()`. Without JSON support, this function is a no-op and all parameters remain at default values.
+**Important:** `-DPE_USE_JSON=ON` is **required** for PE Serial Mode. `-DSED_BENCH=ON` enables the sedimentation benchmark output (e.g. `SED_BENCH_VEL` lines). `-DPE_VERIFY_HASHGRID=OFF` disables hashgrid verification overhead. The setup functions (`setupParticleBenchSerial`, etc.) load runtime configuration from `example.json` via `SimulationConfig::loadFromFile()`. Without JSON support, this function is a no-op and all parameters remain at default values.
 
 The configure banner should show:
 
@@ -120,9 +120,9 @@ bash -c '
     -DBUILD_APPLICATIONS=ON \
     -DUSE_PE=ON \
     -DUSE_PE_SERIAL_MODE=ON \
-    -DUSE_JSON=ON \
+    -DPE_USE_JSON=ON \
     -DSED_BENCH=ON \
-    -DVERIFY_HASHGRID=OFF \
+    -DPE_VERIFY_HASHGRID=OFF \
     -DCMAKE_C_COMPILER=mpicc \
     -DCMAKE_CXX_COMPILER=mpicxx \
     -DCMAKE_Fortran_COMPILER=mpifort
@@ -346,7 +346,7 @@ ls build-ninja-release/applications/q2p1_bench_sedimentation/_data/MG.dat
 
 ### JSON is Required
 
-**Critical:** `-DUSE_JSON=ON` is **mandatory** for PE Serial Mode. The setup functions load runtime configuration from `example.json`, and without JSON support, all parameters remain at default values.
+**Critical:** `-DPE_USE_JSON=ON` is **mandatory** for PE Serial Mode. The setup functions load runtime configuration from `example.json`, and without JSON support, all parameters remain at default values.
 
 CMake's `FetchContent` automatically downloads nlohmann/json from GitHub:
 - Source: `https://github.com/nlohmann/json.git`
@@ -355,7 +355,7 @@ CMake's `FetchContent` automatically downloads nlohmann/json from GitHub:
 
 ### Eigen (Optional)
 
-Eigen support can be disabled with `-DEIGEN=OFF` if you encounter network issues or don't need it for your simulation:
+Eigen support can be disabled with `-DPE_USE_EIGEN=OFF` if you encounter network issues or don't need it for your simulation:
 - Source (when enabled): `https://gitlab.com/libeigen/eigen.git`
 - May fail in restricted network environments
 - Not required for basic sphere sedimentation benchmarks
@@ -366,7 +366,7 @@ If you encounter `Could not resolve host` errors during configure:
 
 1. **Check network/proxy settings** - CMake FetchContent needs internet access
 2. **Use pre-downloaded dependencies** - Advanced: vendor the dependencies locally
-3. **Disable optional components** - Use `-DEIGEN=OFF` if Eigen fetch fails
+3. **Disable optional components** - Use `-DPE_USE_EIGEN=OFF` if Eigen fetch fails
 
 In this guide's tested environment (RHEL 9.7 with standard network access), JSON FetchContent succeeded without issues.
 
@@ -443,7 +443,7 @@ build-ninja-release/
 
 **Issue:** All parameters at default values despite `example.json`
 - **Cause:** PE built without JSON support (`HAVE_JSON` not defined)
-- **Fix:** Reconfigure with `-DUSE_JSON=ON` and rebuild (see Section 2)
+- **Fix:** Reconfigure with `-DPE_USE_JSON=ON` and rebuild (see Section 2)
 
 **Issue:** Partition count mismatch errors at runtime
 - **Cause:** Mesh partitioned to different count than parameter file expects

--- a/docs/md_docs/guide_04_q2p1_atc_pe_serial_fbm_kvel_from_scratch.md
+++ b/docs/md_docs/guide_04_q2p1_atc_pe_serial_fbm_kvel_from_scratch.md
@@ -5,9 +5,9 @@ It documents the exact configuration that was validated for `q2p1_ATC`:
 
 - `-DUSE_PE=ON`
 - `-DUSE_PE_SERIAL_MODE=ON`
-- `-DUSE_JSON=ON`
+- `-DPE_USE_JSON=ON`
 - `-DUSE_CGAL=ON`
-- `-DEIGEN=ON`
+- `-DPE_USE_EIGEN=ON`
 - `-DENABLE_FBM_ACCELERATION=ON` (HashGrid + KVEL force acceleration)
 
 ## 1) Environment Setup (GCC 13 validated stack)
@@ -82,9 +82,9 @@ cmake -S . -B build-atc-ninja-release-eigen -G Ninja \
   -DBUILD_APPLICATIONS=ON \
   -DUSE_PE=ON \
   -DUSE_PE_SERIAL_MODE=ON \
-  -DUSE_JSON=ON \
+  -DPE_USE_JSON=ON \
   -DUSE_CGAL=ON \
-  -DEIGEN=ON \
+  -DPE_USE_EIGEN=ON \
   -DENABLE_FBM_ACCELERATION=ON \
   -DCMAKE_C_COMPILER=mpicc \
   -DCMAKE_CXX_COMPILER=mpicxx \
@@ -99,9 +99,9 @@ cmake -S . -B build-atc-ninja-release-eigen-gcc14 -G Ninja \
   -DBUILD_APPLICATIONS=ON \
   -DUSE_PE=ON \
   -DUSE_PE_SERIAL_MODE=ON \
-  -DUSE_JSON=ON \
+  -DPE_USE_JSON=ON \
   -DUSE_CGAL=ON \
-  -DEIGEN=ON \
+  -DPE_USE_EIGEN=ON \
   -DENABLE_FBM_ACCELERATION=ON \
   -DCMAKE_C_COMPILER=mpicc \
   -DCMAKE_CXX_COMPILER=mpicxx \
@@ -155,22 +155,22 @@ ls -lh build-atc-ninja-release-eigen-gcc14/applications/q2p1_ATC/q2p1_ATC
 Verify CMake cache options:
 
 ```bash
-rg -n "^(EIGEN|USE_PE|USE_PE_SERIAL_MODE|USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
+rg -n "^(PE_USE_EIGEN|USE_PE|USE_PE_SERIAL_MODE|PE_USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
   build-atc-ninja-release-eigen/CMakeCache.txt
 ```
 
 For the GCC 14 build:
 
 ```bash
-rg -n "^(EIGEN|USE_PE|USE_PE_SERIAL_MODE|USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
+rg -n "^(PE_USE_EIGEN|USE_PE|USE_PE_SERIAL_MODE|PE_USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
   build-atc-ninja-release-eigen-gcc14/CMakeCache.txt
 ```
 
 Expected values:
-- `EIGEN:BOOL=ON`
+- `PE_USE_EIGEN:BOOL=ON`
 - `USE_PE:BOOL=ON`
 - `USE_PE_SERIAL_MODE:BOOL=ON`
-- `USE_JSON:BOOL=ON`
+- `PE_USE_JSON:BOOL=ON`
 - `USE_CGAL:BOOL=ON`
 - `ENABLE_FBM_ACCELERATION:BOOL=ON`
 

--- a/docs/md_docs/guide_06_q2p1_bench_fluidization_pe_serial_fbm_kvel_gcc14_from_scratch.md
+++ b/docs/md_docs/guide_06_q2p1_bench_fluidization_pe_serial_fbm_kvel_gcc14_from_scratch.md
@@ -13,8 +13,8 @@ The validated configuration is:
 
 - `-DUSE_PE=ON`
 - `-DUSE_PE_SERIAL_MODE=ON`
-- `-DUSE_JSON=ON`
-- `-DEIGEN=ON`
+- `-DPE_USE_JSON=ON`
+- `-DPE_USE_EIGEN=ON`
 - `-DENABLE_FBM_ACCELERATION=ON` (HashGrid + KVEL force acceleration)
 - `-DUSE_CGAL=OFF` (default; CGAL is not needed for `q2p1_bench_fluidization`)
 - GCC/G++/GFortran 14.3.0 through the OpenMPI 4.1.6 GCC 14 wrapper compilers
@@ -71,7 +71,7 @@ Important for this build:
 
 - PE is built from `libs/pe`.
 - FullC0ntact is configured as a subproject.
-- Eigen is required because this guide uses `-DEIGEN=ON`.
+- Eigen is required because this guide uses `-DPE_USE_EIGEN=ON`.
 
 Quick check:
 
@@ -92,8 +92,8 @@ cmake -S . -B build-q2p1-bench-fluidization-gcc14-pe-serial-fbm -G Ninja \
   -DBUILD_APPLICATIONS=ON \
   -DUSE_PE=ON \
   -DUSE_PE_SERIAL_MODE=ON \
-  -DUSE_JSON=ON \
-  -DEIGEN=ON \
+  -DPE_USE_JSON=ON \
+  -DPE_USE_EIGEN=ON \
   -DENABLE_FBM_ACCELERATION=ON \
   -DCMAKE_C_COMPILER=mpicc \
   -DCMAKE_CXX_COMPILER=mpicxx \
@@ -153,7 +153,7 @@ Validated result:
 Verify the important CMake cache options:
 
 ```bash
-rg -n "^(CMAKE_(C|CXX|Fortran)_COMPILER|EIGEN|USE_PE|USE_PE_SERIAL_MODE|USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
+rg -n "^(CMAKE_(C|CXX|Fortran)_COMPILER|PE_USE_EIGEN|USE_PE|USE_PE_SERIAL_MODE|PE_USE_JSON|USE_CGAL|ENABLE_FBM_ACCELERATION):" \
   build-q2p1-bench-fluidization-gcc14-pe-serial-fbm/CMakeCache.txt
 ```
 
@@ -162,10 +162,10 @@ Expected values:
 - `CMAKE_C_COMPILER:UNINITIALIZED=mpicc`
 - `CMAKE_CXX_COMPILER:UNINITIALIZED=mpicxx`
 - `CMAKE_Fortran_COMPILER:UNINITIALIZED=mpifort`
-- `EIGEN:BOOL=ON`
+- `PE_USE_EIGEN:BOOL=ON`
 - `ENABLE_FBM_ACCELERATION:BOOL=ON`
 - `USE_CGAL:BOOL=OFF`
-- `USE_JSON:BOOL=ON`
+- `PE_USE_JSON:BOOL=ON`
 - `USE_PE:BOOL=ON`
 - `USE_PE_SERIAL_MODE:BOOL=ON`
 

--- a/docs/md_docs/hashgrid_verification.md
+++ b/docs/md_docs/hashgrid_verification.md
@@ -32,8 +32,8 @@ module load gcc/latest-v13 openmpi/options/interface/ethernet openmpi/4.1.6
 cmake -DCMAKE_BUILD_TYPE=Release \
       -DUSE_PE=ON \
       -DUSE_PE_SERIAL_MODE=ON \
-      -DUSE_ACCELERATED_POINT_QUERY=ON \
-      -DVERIFY_HASHGRID=ON \
+      -DPE_USE_ACCELERATED_POINT_QUERY=ON \
+      -DPE_VERIFY_HASHGRID=ON \
       -DBUILD_APPLICATIONS=ON \
       ..
 
@@ -42,9 +42,9 @@ make -j8
 
 ### CMake Options
 
-- **`USE_ACCELERATED_POINT_QUERY=ON`** - Enable HashGrid acceleration (required for verification)
-- **`VERIFY_HASHGRID=ON`** - Enable runtime verification
-- **`VERIFY_HASHGRID=OFF`** - Disable verification (default, for production runs)
+- **`PE_USE_ACCELERATED_POINT_QUERY=ON`** - Enable HashGrid acceleration (required for verification)
+- **`PE_VERIFY_HASHGRID=ON`** - Enable runtime verification
+- **`PE_VERIFY_HASHGRID=OFF`** - Disable verification (default, for production runs)
 
 ## Output Format
 
@@ -123,7 +123,7 @@ HashGrid verification: 500000 queries, 0 mismatches (  0.0000%)
 ```bash
 # Build with verification
 cd build_verify
-cmake -DUSE_ACCELERATED_POINT_QUERY=ON -DVERIFY_HASHGRID=ON ..
+cmake -DPE_USE_ACCELERATED_POINT_QUERY=ON -DPE_VERIFY_HASHGRID=ON ..
 make -j8 q2p1_hashgrid_test
 
 # Run test (will be slower)
@@ -143,7 +143,7 @@ cd ../..
 mkdir build_production
 cd build_production
 
-cmake -DUSE_ACCELERATED_POINT_QUERY=ON -DVERIFY_HASHGRID=OFF ..
+cmake -DPE_USE_ACCELERATED_POINT_QUERY=ON -DPE_VERIFY_HASHGRID=OFF ..
 make -j8
 
 # Now run at full speed
@@ -192,13 +192,13 @@ The build system:
 **Error:**
 ```
 CMake Warning:
-  VERIFY_HASHGRID is enabled but USE_ACCELERATED_POINT_QUERY is OFF.
+  PE_VERIFY_HASHGRID is enabled but PE_USE_ACCELERATED_POINT_QUERY is OFF.
   Verification requires acceleration to be enabled.
 ```
 
 **Solution:** Enable both options:
 ```bash
-cmake -DUSE_ACCELERATED_POINT_QUERY=ON -DVERIFY_HASHGRID=ON ..
+cmake -DPE_USE_ACCELERATED_POINT_QUERY=ON -DPE_VERIFY_HASHGRID=ON ..
 ```
 
 ### No verification output during run

--- a/docs/md_docs/pe_initialization.md
+++ b/docs/md_docs/pe_initialization.md
@@ -467,7 +467,7 @@ WARNING: DistanceMap acceleration failed to initialize for chip
 ```bash
 # Rebuild PE library with CGAL
 cd libs/pe/build
-cmake -DCGAL=ON ..
+cmake -DPE_USE_CGAL=ON ..
 make -j8
 ```
 

--- a/el-frozen/README.md
+++ b/el-frozen/README.md
@@ -58,9 +58,9 @@ Implemented so far:
 - successful configure/build path with:
   - `USE_PE=ON`
   - `USE_PE_SERIAL_MODE=ON`
-  - `USE_JSON=ON`
+  - `PE_USE_JSON=ON`
   - `USE_CGAL=OFF`
-  - `EIGEN=ON`
+  - `PE_USE_EIGEN=ON`
   - `ENABLE_FBM_ACCELERATION=ON`
 
 Important implementation correction already identified:


### PR DESCRIPTION
Align FeatFloWer with PE's PE_-prefixed CMake options

Summary

The pe submodule (commit fda0a46d) renamed all PE-owned CMake options to a consistent PE_ prefix and removed the old unprefixed names, including the USE_CGAL →
CGAL deprecated alias. FeatFloWer configured the PE subbuild using those old names, so after bumping the submodule pointer those settings silently stopped reaching
PE. This PR realigns FeatFloWer's build wiring and documentation with the new option names, and forwards the libs/pe pointer to fda0a46d.

Why this matters

Without these changes, a FeatFloWer build against the new PE would have:

PE built without MPI even in parallel mode (root set MPI; PE now reads PE_USE_MPI)
PE built without CGAL even with USE_CGAL=ON (the alias that forwarded it is gone)
FBM HashGrid acceleration not enabled in PE (root set USE_ACCELERATED_POINT_QUERY; PE now reads PE_USE_ACCELERATED_POINT_QUERY)
Changes

CMakeLists.txt (functional):

Rename the dependent option MPI → PE_USE_MPI
Forward FBM acceleration via PE_USE_ACCELERATED_POINT_QUERY instead of USE_ACCELERATED_POINT_QUERY
Add explicit forwarding of USE_CGAL=ON → PE_USE_CGAL=ON before add_subdirectory(libs/pe), replacing the removed alias and keeping PE's CGAL code paths compiled
Documentation: Update PE option references (both prose and -D command-line forms) to the PE_ prefix across build_guide.md, GEMINI.md, the from-scratch guides
(guide_02/04/06), hashgrid_verification.md, pe_initialization.md, and the q2p1_hashgrid_test / el-frozen READMEs.

Submodule: Forward libs/pe pointer 643fd9dd → fda0a46d.

Deliberately unchanged

The C++ compile defines USE_ACCELERATED_POINT_QUERY and VERIFY_HASHGRID stay unprefixed — PE keeps them that way because the sources test them. Only the CMake
options gained the PE_ prefix. FullC0ntact's own USE_EIGEN/USE_CGAL options are a separate namespace and untouched.

Verification

Configure-only checks (full build not run here):

Parallel PE + FBM: cmake -DUSE_PE=ON -DENABLE_FBM_ACCELERATION=ON .. → exit 0; cache shows PE_USE_MPI=ON, PE_USE_ACCELERATED_POINT_QUERY=ON; status prints "PE
Parallel Mode … Full MPI parallelization" and "Accelerated point query … ENABLED"
Serial PE (two-step): PE_USE_MPI correctly resolves OFF
CGAL forwarding (-DUSE_CGAL=ON) sets PE_USE_CGAL=ON in cache
🤖 Generated with Claude Code